### PR TITLE
Standardize molecular properties

### DIFF
--- a/jointformer/utils/properties/smiles/guacamol_mpo.py
+++ b/jointformer/utils/properties/smiles/guacamol_mpo.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from guacamol import standard_benchmarks
+from typing import Optional
+
+from jointformer.utils.properties.smiles.base import BaseTarget
+
+GUACAMOL_MPO_DEFAULT_DTYPE = np.float64
+
+GUACAMOL_MPO_TASK_FN = {
+    'amlodipine': standard_benchmarks.amlodipine_rings(),
+    'fexofenadine': standard_benchmarks.hard_fexofenadine(),
+    'osimertinib': standard_benchmarks.hard_osimertinib(),
+    'perindopril': standard_benchmarks.perindopril_rings(),
+    'sitagliptin': standard_benchmarks.sitagliptin_replacement(),
+    'ranolazine': standard_benchmarks.ranolazine_mpo(),
+    'zaleplon': standard_benchmarks.zaleplon_with_other_formula(),
+}
+
+
+class GuacamolMPO(BaseTarget):
+    """ Guacamol MPO targets.
+    Source: 
+    """
+    
+    def _get_target(self, example: str, dtype: Optional[np.dtype] = GUACAMOL_MPO_DEFAULT_DTYPE) -> float:
+        try: 
+            target = np.array(list(map(lambda fn: fn.objective.score(example), GUACAMOL_MPO_TASK_FN.values())), dtype=dtype)
+            target[target < 0] = np.nan
+            return target
+        except Exception:
+            return np.full(len(GUACAMOL_MPO_TASK_FN), np.nan)
+
+    @property
+    def target_names(self):
+        return list(GUACAMOL_MPO_TASK_FN.keys())
+
+    def __repr__(self):
+        return "GuacamolMPO"
+
+    def __str__(self):
+        return "GuacamolMPO"

--- a/jointformer/utils/properties/smiles/guacamol_mpo.py
+++ b/jointformer/utils/properties/smiles/guacamol_mpo.py
@@ -20,7 +20,6 @@ GUACAMOL_MPO_TASK_FN = {
 
 class GuacamolMPO(BaseTarget):
     """ Guacamol MPO targets.
-    Source: 
     """
     
     def _get_target(self, example: str, dtype: Optional[np.dtype] = GUACAMOL_MPO_DEFAULT_DTYPE) -> float:

--- a/jointformer/utils/properties/smiles/plogp.py
+++ b/jointformer/utils/properties/smiles/plogp.py
@@ -1,3 +1,4 @@
+import networkx as nx
 import numpy as np
 
 from rdkit import Chem
@@ -6,14 +7,43 @@ from rdkit.Chem import Descriptors
 from jointformer.utils.properties.smiles import sascorer
 from jointformer.utils.properties.smiles.base import BaseTarget
 
+logP_mean = 2.4570953396190123
+logP_std = 1.434324401111988
+sa_mean = -3.0525811293166134
+sa_std = 0.8335207024513095
+cycle_mean = -0.0485696876403053
+cycle_std = 0.2860212110245455
+
 
 class PlogP(BaseTarget):
-    """ pLogP target. """
-
+    """ Penalized LogP target.
+    Source: https://github.com/wengong-jin/hgraph2graph/blob/master/props/properties.py
+    """
+    
     def _get_target(self, example: str) -> float:
-        try:
-            return Descriptors.MolLogP(Chem.MolFromSmiles(example)) \
-                     - sascorer.calculateScore(Chem.MolFromSmiles(example))
+        try: 
+            mol = Chem.MolFromSmiles(s)
+            log_p = Descriptors.MolLogP(mol)
+            sa = -sascorer.calculateScore(mol)
+
+            # cycle score
+            cycle_list = nx.cycle_basis(nx.Graph(Chem.rdmolops.GetAdjacencyMatrix(mol)))
+            if len(cycle_list) == 0:
+                cycle_length = 0
+            else:
+                cycle_length = max([len(j) for j in cycle_list])
+            if cycle_length <= 6:
+                cycle_length = 0
+            else:
+                cycle_length = cycle_length - 6
+            cycle_score = -cycle_length
+
+            # normalize
+            normalized_log_p = (log_p - logP_mean) / logP_std
+            normalized_sa = (sa - sa_mean) / sa_std
+            normalized_cycle = (cycle_score - cycle_mean) / cycle_std
+            
+            return normalized_log_p + normalized_sa + normalized_cycle
         except Exception:
             return np.nan
 
@@ -22,7 +52,7 @@ class PlogP(BaseTarget):
         return ["plogp"]
 
     def __repr__(self):
-        return "pLogP"
+        return "PenalizedLogP"
 
     def __str__(self):
-        return "pLogP"
+        return "PenalizedLogP"

--- a/jointformer/utils/properties/smiles/plogp.py
+++ b/jointformer/utils/properties/smiles/plogp.py
@@ -22,7 +22,7 @@ class PlogP(BaseTarget):
     
     def _get_target(self, example: str) -> float:
         try: 
-            mol = Chem.MolFromSmiles(s)
+            mol = Chem.MolFromSmiles(example)
             log_p = Descriptors.MolLogP(mol)
             sa = -sascorer.calculateScore(mol)
 

--- a/jointformer/utils/properties/smiles/qed.py
+++ b/jointformer/utils/properties/smiles/qed.py
@@ -7,11 +7,13 @@ from jointformer.utils.properties.smiles.base import BaseTarget
 
 
 class QED(BaseTarget):
-    """ QED target. """
+    """ QED target. 
+    Source: https://github.com/wengong-jin/hgraph2graph/blob/master/props/properties.py
+    """
 
     def _get_target(self, example: str) -> float:
         try:
-            return qed(Chem.MolFromSmiles(example, sanitize=False))
+            return qed(Chem.MolFromSmiles(example))
         except Exception:
             return np.nan
 


### PR DESCRIPTION
Standardizes QED and penalized LogP calculation to follow the molecular property optimization literature, following: 
QED: https://github.com/wengong-jin/hgraph2graph/blob/e396dbaf43f9d4ac2ee2568a4d5f93ad9e78b767/props/properties.py#L28
penalized LogP: https://github.com/wengong-jin/hgraph2graph/blob/e396dbaf43f9d4ac2ee2568a4d5f93ad9e78b767/props/properties.py#L35

Note that this is different from what MoLeR uses for joint training, as MoLeR uses a non penalized version of LogP:
https://github.com/microsoft/molecule-generation/blob/48d532f7e95dff822a84ffd603f41253ac07dbdd/molecule_generation/chem/molecule_dataset_utils.py#L666

Adds calculation of Guacamol MPO objectives